### PR TITLE
Improve environment validation and UI feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+venv/
+ENV/
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Insta Doctor
+
+Insta Doctor is a simple Flask application that provides an AI powered medical chat assistant.
+
+## Requirements
+
+- Python 3.8+
+- Dependencies listed in `requirements.txt`
+
+## Setup
+
+1. Clone the repository and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set the following environment variables:
+
+- `OPENAI_API_KEY` – API key for OpenAI.
+- `ASSISTANT_ID` – ID of the assistant you created on OpenAI.
+- `SECRET_KEY` – Secret key used by Flask for sessions.
+
+3. Run the application locally:
+
+```bash
+python app.py
+```
+
+The server will start on `http://localhost:8080` and you can navigate to `/chat` to start chatting.
+

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -18,7 +18,11 @@
             body: JSON.stringify({message: msg})
         });
         const data = await res.json();
-        document.getElementById('response').innerText = data.reply || "No reply.";
+        if (data.need_login) {
+            document.getElementById('response').innerText = 'Daily limit reached, please log in.';
+        } else {
+            document.getElementById('response').innerText = data.reply || 'No reply.';
+        }
     }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add `README.md` explaining how to run the app and required env vars
- ignore virtualenv and Python bytecode via `.gitignore`
- validate `OPENAI_API_KEY` and `ASSISTANT_ID` at startup
- handle failed/expired runs from OpenAI
- show login requirement in the chat UI

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6856e6f7a1fc832696202fd79e00f0b7