### PR TITLE
Improve chat UX with session thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+venv/
+ENV/
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Insta Doctor
+
+Insta Doctor is a simple Flask application that provides an AI powered medical chat assistant.
+
+## Requirements
+
+- Python 3.8+
+- Dependencies listed in `requirements.txt`
+
+## Setup
+
+1. Clone the repository and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set the following environment variables:
+
+- `OPENAI_API_KEY` – API key for OpenAI.
+- `ASSISTANT_ID` – ID of the assistant you created on OpenAI.
+- `SECRET_KEY` – Secret key used by Flask for sessions.
+
+3. Run the application locally:
+
+```bash
+python app.py
+```
+
+The server will start on `http://localhost:8080` and you can navigate to `/chat` to start chatting.
+
+### Accounts
+
+Users can sign up or log in before chatting. Accounts are stored in a local SQLite database (`instadoctor.db`). If you send more than three messages without an account you will be asked to log in.
+
+### Medical Intake
+
+When you first visit `/chat` you will be redirected to `/intake` to provide
+basic information like name, age, gender, symptoms and duration. This data is
+sent to the assistant only once at the beginning of the conversation so it can
+better tailor its responses.
+
+### Uploading Files
+
+On the chat page you can optionally upload PDF or image files (such as lab
+results) using the file input below the message box. Uploaded files are attached
+to your session's conversation thread and are accessible to the OpenAI assistant
+for reference in subsequent replies.
+

--- a/app.py
+++ b/app.py
@@ -1,13 +1,41 @@
-from flask import Flask, render_template, request, session, jsonify
+from flask import Flask, render_template, request, session, jsonify, redirect
+from werkzeug.utils import secure_filename
+from werkzeug.security import generate_password_hash, check_password_hash
 from openai import OpenAI
-import os, time
+import os, time, sqlite3
+
+# Validate environment configuration
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+ASSISTANT_ID = os.getenv("ASSISTANT_ID")
+if not OPENAI_API_KEY:
+    raise RuntimeError("OPENAI_API_KEY environment variable is required")
+if not ASSISTANT_ID:
+    raise RuntimeError("ASSISTANT_ID environment variable is required")
 
 # Initialize OpenAI client with secure API key
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-ASSISTANT_ID = os.getenv("ASSISTANT_ID")
+client = OpenAI(api_key=OPENAI_API_KEY)
 
 app = Flask(__name__)
 app.secret_key = os.getenv("SECRET_KEY") or "secret"
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "instadoctor.db")
+
+def init_db():
+    with sqlite3.connect(DB_PATH) as db:
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                password TEXT NOT NULL
+            )"""
+        )
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+init_db()
 
 FREE_LIMIT_VISITOR = 3
 
@@ -18,29 +46,38 @@ def todays_counter():
     session.modified = True
     return counter
 
-def ask_doctor_virtual(msg):
+def ask_doctor_virtual(msg, thread_id, file_ids=None):
     print(f"🟡 Sending to GPT: {msg}")
     try:
-        thread = client.beta.threads.create()
+        attachments = None
+        if file_ids:
+            attachments = [
+                {"file_id": fid, "tools": [{"type": "file_search"}]}
+                for fid in file_ids
+            ]
+
         client.beta.threads.messages.create(
-            thread_id=thread.id,
+            thread_id=thread_id,
             role="user",
-            content=msg
+            content=msg,
+            attachments=attachments,
         )
         run = client.beta.threads.runs.create(
-            thread_id=thread.id,
+            thread_id=thread_id,
             assistant_id=ASSISTANT_ID
         )
         while True:
             status = client.beta.threads.runs.retrieve(
                 run_id=run.id,
-                thread_id=thread.id
+                thread_id=thread_id
             )
             if status.status == "completed":
                 break
+            if status.status in ["failed", "cancelled", "expired", "requires_action"]:
+                raise RuntimeError(f"Run {status.status}")
             time.sleep(1)
 
-        messages = client.beta.threads.messages.list(thread_id=thread.id)
+        messages = client.beta.threads.messages.list(thread_id=thread_id)
         reply = messages.data[0].content[0].text.value
         print("✅ GPT Reply:", reply)
         return reply
@@ -51,24 +88,134 @@ def ask_doctor_virtual(msg):
 
 @app.route("/")
 def home():
-    return render_template("index.html")
+    return render_template("index.html", logged_in=bool(session.get("user_id")))
+
+
+@app.route("/signup", methods=["GET", "POST"])
+def signup():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+        if not username or not password:
+            return render_template("signup.html", error="All fields required")
+        hashed = generate_password_hash(password)
+        try:
+            with get_db() as db:
+                cur = db.execute(
+                    "INSERT INTO users (username, password) VALUES (?, ?)",
+                    (username, hashed),
+                )
+                user_id = cur.lastrowid
+            session["user_id"] = user_id
+            session.modified = True
+            return redirect("/chat")
+        except sqlite3.IntegrityError:
+            return render_template("signup.html", error="Username taken")
+    return render_template("signup.html")
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+        with get_db() as db:
+            user = db.execute(
+                "SELECT * FROM users WHERE username=?", (username,)
+            ).fetchone()
+        if not user or not check_password_hash(user["password"], password):
+            return render_template("login.html", error="Invalid credentials")
+        session["user_id"] = user["id"]
+        session.modified = True
+        return redirect("/chat")
+    return render_template("login.html")
+
+
+@app.route("/logout")
+def logout():
+    session.pop("user_id", None)
+    return redirect("/")
+
+@app.route("/intake", methods=["GET", "POST"])
+def intake():
+    if request.method == "POST":
+        session["intake"] = {
+            "name": request.form.get("name", ""),
+            "age": request.form.get("age", ""),
+            "gender": request.form.get("gender", ""),
+            "symptoms": request.form.get("symptoms", ""),
+            "duration": request.form.get("duration", ""),
+        }
+        session["intake_submitted"] = True
+        session["intake_used"] = False
+        session.modified = True
+        return redirect("/chat")
+    return render_template("intake.html")
+
+@app.route("/upload", methods=["POST"])
+def upload():
+    thread_id = session.get("thread_id")
+    if not thread_id:
+        thread = client.beta.threads.create()
+        thread_id = thread.id
+        session["thread_id"] = thread_id
+        session.modified = True
+
+    file_ids = session.get("file_ids", [])
+    uploaded = request.files.getlist("file")
+    new_ids = []
+    for f in uploaded:
+        if not f:
+            continue
+        filename = secure_filename(f.filename)
+        openai_file = client.files.create(file=(filename, f.stream, f.mimetype), purpose="assistants")
+        new_ids.append(openai_file.id)
+    if new_ids:
+        file_ids.extend(new_ids)
+        session["file_ids"] = file_ids
+        session.modified = True
+    return jsonify({"uploaded": new_ids})
 
 @app.route("/chat", methods=["GET", "POST"])
 def chat():
     if request.method == "GET":
-        return render_template("chat.html")
+        if not session.get("intake_submitted"):
+            return redirect("/intake")
+        return render_template("chat.html", logged_in=bool(session.get("user_id")))
 
     data = request.get_json()
-    count = todays_counter()
-
-    if count > FREE_LIMIT_VISITOR:
-        return jsonify({"need_login": True})
+    if not session.get("user_id"):
+        count = todays_counter()
+        if count > FREE_LIMIT_VISITOR:
+            return jsonify({"need_login": True})
 
     user_msg = data.get("message", "").strip()
     if not user_msg:
         return jsonify({"reply": "❗️Please enter a message."})
 
-    reply = ask_doctor_virtual(user_msg)
+    if session.get("intake_submitted") and not session.get("intake_used"):
+        info = session.get("intake", {})
+        prefix = (
+            f"Patient Info:\n"
+            f"Name: {info.get('name')}\n"
+            f"Age: {info.get('age')}\n"
+            f"Gender: {info.get('gender')}\n"
+            f"Symptoms: {info.get('symptoms')}\n"
+            f"Duration: {info.get('duration')}\n"
+        )
+        user_msg = prefix + "\n" + user_msg
+        session["intake_used"] = True
+        session.modified = True
+
+    thread_id = session.get("thread_id")
+    if not thread_id:
+        thread = client.beta.threads.create()
+        thread_id = thread.id
+        session["thread_id"] = thread_id
+        session.modified = True
+
+    file_ids = session.get("file_ids")
+    reply = ask_doctor_virtual(user_msg, thread_id, file_ids)
     return jsonify({"reply": reply})
 
 if __name__ == "__main__":

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -2,23 +2,68 @@
 <html>
 <head>
     <title>Chat with Doctor Virtual</title>
+    <style>
+        body { background:#fff3e0; font-family: Arial; }
+        header { background:#fb8c00; color:white; padding:10px; }
+        #chatlog { height:300px; overflow-y:auto; border:1px solid #ccc; padding:5px; margin-bottom:10px; background:#ffffff; }
+        button { background:#fb8c00; color:white; border:none; padding:6px 12px; margin-top:5px; }
+    </style>
 </head>
 <body>
+    <header>
+        <a href="/" style="color:white; text-decoration:none;">Home</a>
+        {% if logged_in %}
+          <a href="/logout" style="color:white; margin-left:10px;">Logout</a>
+        {% else %}
+          <a href="/login" style="color:white; margin-left:10px;">Login</a>
+          <a href="/signup" style="color:white; margin-left:10px;">Sign Up</a>
+        {% endif %}
+    </header>
     <h2>Chat with Doctor Virtual</h2>
-    <textarea id="input" rows="4" cols="50" placeholder="Describe your symptoms..."></textarea><br>
+    <div id="chatlog"></div>
+    <textarea id="input" rows="3" cols="50" placeholder="Describe your symptoms..."></textarea><br>
     <button onclick="send()">Send</button>
-    <div id="response" style="margin-top:20px;"></div>
+    <br><br>
+    <input type="file" id="file" multiple accept="image/*,application/pdf">
+    <button onclick="upload()">Upload</button>
 
     <script>
     async function send() {
         const msg = document.getElementById('input').value;
+        if (!msg.trim()) return;
+        document.getElementById('input').value = '';
+
+        const log = document.getElementById('chatlog');
+        log.innerHTML += `<div><strong>You:</strong> ${msg}</div>`;
+
         const res = await fetch('/chat', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({message: msg})
         });
         const data = await res.json();
-        document.getElementById('response').innerText = data.reply || "No reply.";
+        if (data.need_login) {
+            log.innerHTML += `<div><em>Daily limit reached, please log in.</em></div>`;
+        } else {
+            log.innerHTML += `<div><strong>Doctor:</strong> ${data.reply || 'No reply.'}</div>`;
+        }
+        log.scrollTop = log.scrollHeight;
+    }
+
+    async function upload() {
+        const fileInput = document.getElementById('file');
+        if (!fileInput.files.length) return;
+        const form = new FormData();
+        for (const f of fileInput.files) {
+            form.append('file', f);
+        }
+        fileInput.value = '';
+
+        const res = await fetch('/upload', { method: 'POST', body: form });
+        const data = await res.json();
+        const log = document.getElementById('chatlog');
+        log.innerHTML += `<div><em>Uploaded files: ${data.uploaded.join(', ')}</em></div>`;
+        log.scrollTop = log.scrollHeight;
     }
     </script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,10 +2,21 @@
 <html>
 <head>
     <title>Doctor Virtual</title>
+    <style>
+        body { background:#e8eaf6; font-family: Arial; text-align:center; }
+        h1 { color:#3f51b5; }
+        a.button { display:inline-block; padding:10px 20px; margin:5px; background:#3f51b5; color:white; text-decoration:none; border-radius:4px; }
+    </style>
 </head>
 <body>
     <h1>Welcome to Insta Doctor</h1>
     <p>Your AI medical assistant is ready.</p>
-    <a href="/chat">→ Start Chat</a>
+    <a class="button" href="/chat">Start Chat</a>
+    {% if logged_in %}
+      <a class="button" href="/logout">Logout</a>
+    {% else %}
+      <a class="button" href="/login">Login</a>
+      <a class="button" href="/signup">Sign Up</a>
+    {% endif %}
 </body>
 </html>

--- a/templates/intake.html
+++ b/templates/intake.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Medical Intake</title>
+    <style>
+        body { background:#e8f5e9; font-family: Arial; }
+        header { background:#43a047; color:white; padding:10px; }
+        form { margin:20px; background:#fff; padding:15px; border-radius:8px; }
+        button { background:#43a047; color:white; border:none; padding:6px 12px; }
+    </style>
+</head>
+<body>
+    <header>
+        <a href="/" style="color:white; text-decoration:none;">Home</a>
+    </header>
+    <h2>Provide your medical information</h2>
+    <form method="post">
+        <label>Name: <input type="text" name="name" required></label><br>
+        <label>Age: <input type="number" name="age" required></label><br>
+        Gender:
+        <label><input type="radio" name="gender" value="Male" required>Male</label>
+        <label><input type="radio" name="gender" value="Female">Female</label>
+        <label><input type="radio" name="gender" value="Other">Other</label><br>
+        <label>Symptoms:<br>
+            <textarea name="symptoms" rows="4" cols="50" required></textarea>
+        </label><br>
+        <label>Duration of illness: <input type="text" name="duration" required></label><br>
+        <button type="submit">Submit</button>
+    </form>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login - Insta Doctor</title>
+    <style>
+        body { background:#e0f7fa; font-family: Arial; text-align:center; }
+        form { display:inline-block; padding:20px; background:#fff; border-radius:8px; }
+        input { margin:5px; padding:5px; }
+        button { background:#00796b; color:white; border:none; padding:8px 16px; }
+        a { color:#00796b; }
+    </style>
+</head>
+<body>
+    <h2>Login</h2>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <input name="username" placeholder="Username" required><br>
+        <input name="password" type="password" placeholder="Password" required><br>
+        <button type="submit">Login</button>
+    </form>
+    <p>Don't have an account? <a href="/signup">Sign up</a></p>
+</body>
+</html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Sign Up - Insta Doctor</title>
+    <style>
+        body { background:#fce4ec; font-family: Arial; text-align:center; }
+        form { display:inline-block; padding:20px; background:#fff; border-radius:8px; }
+        input { margin:5px; padding:5px; }
+        button { background:#c2185b; color:white; border:none; padding:8px 16px; }
+        a { color:#c2185b; }
+    </style>
+</head>
+<body>
+    <h2>Create Account</h2>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <input name="username" placeholder="Username" required><br>
+        <input name="password" type="password" placeholder="Password" required><br>
+        <button type="submit">Sign Up</button>
+    </form>
+    <p>Already have an account? <a href="/login">Login</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- maintain an OpenAI thread per session so conversation history is preserved
- update `/chat` HTML to show a running chat log instead of single replies
- added ability to upload PDFs/images to include in the thread
- detail new intake flow and uploads in README
- implement account signup/login with SQLite and creative UI styling

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e6f7a1fc832696202fd79e00f0b7